### PR TITLE
feat: add init job for DB initialization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,23 @@ Installation
 Usage
 *****
 
+First, enable the plugin itself
+
 .. code-block:: bash
 
     tutor plugins enable postgresql
+
+Then, we need to build the openedx to bind the necessary postgresql packages and libraries into the image
+
+.. code-block:: bash
+
+    tutor images build openedx
+
+Finally, launch the platform to initialize the database with the services.
+
+.. code-block:: bash
+
+    tutor local launch
 
 
 License

--- a/tutorpostgresql/patches/local-docker-compose-jobs-services
+++ b/tutorpostgresql/patches/local-docker-compose-jobs-services
@@ -1,0 +1,3 @@
+postgresql-job:
+    image: {{ POSTGRESQL_IMAGE }}
+    depends_on: {{ [("postgresql", RUN_POSTGRESQL)]|list_if }}

--- a/tutorpostgresql/patches/local-docker-compose-services
+++ b/tutorpostgresql/patches/local-docker-compose-services
@@ -5,7 +5,6 @@ postgresql:
   volumes:
     - ../../data/postgresql:/var/lib/postgresql/data
   environment:
-    - POSTGRES_PASSWORD={{POSTGRESQL_PASSWORD}}
-    - POSTGRES_USER={{POSTGRESQL_USER}}
-    - POSTGRES_DB={{POSTGRESQL_DB}}
+    - POSTGRES_PASSWORD={{POSTGRESQL_ROOT_PASSWORD}}
+    - POSTGRES_USER={{POSTGRESQL_ROOT_USER}}
 {% endif %}

--- a/tutorpostgresql/patches/openedx-auth
+++ b/tutorpostgresql/patches/openedx-auth
@@ -1,0 +1,11 @@
+{%- if RUN_POSTGRESQL and not RUN_MYSQL %}
+DATABASES:
+  default:
+    ENGINE: "django.db.backends.postgresql"
+    HOST: "{{ POSTGRESQL_HOST }}"
+    PORT: {{ POSTGRESQL_PORT }}
+    NAME: "{{ POSTGRESQL_OPENEDX_DB }}"
+    USER: "{{ POSTGRESQL_OPENEDX_USER }}"
+    PASSWORD: "{{ POSTGRESQL_OPENEDX_PASSWORD }}"
+    ATOMIC_REQUESTS: true
+{%- endif %}

--- a/tutorpostgresql/templates/postgresql/tasks/postgresql/init
+++ b/tutorpostgresql/templates/postgresql/tasks/postgresql/init
@@ -1,0 +1,21 @@
+echo "Initialising postgresql..."
+postgresql_connection_max_attempts=10
+postgresql_connection_attempt=0
+until pg_isready -d "postgresql://{{ POSTGRESQL_ROOT_USER }}:{{ POSTGRESQL_ROOT_PASSWORD }}@{{ POSTGRESQL_HOST }}:{{ POSTGRESQL_PORT }}"
+do
+    postgresql_connection_attempt=$(expr $postgresql_connection_attempt + 1)
+    echo "    [$postgresql_connection_attempt/$postgresql_connection_max_attempts] Waiting for postgresql service (this may take a while)..."
+    if [ $postgresql_connection_attempt -eq $postgresql_connection_max_attempts ]
+    then
+      echo "postgresql initialisation error" 1>&2
+      exit 1
+    fi
+    sleep 10
+done
+echo "postgresql is up and running"
+
+# edx-platform database
+psql postgresql://{{ POSTGRESQL_ROOT_USER }}:{{ POSTGRESQL_ROOT_PASSWORD }}@{{ POSTGRESQL_HOST }}:{{ POSTGRESQL_PORT }} -c "CREATE DATABASE {{ POSTGRESQL_OPENEDX_DB }};" 2>/dev/null || echo "Database {{ POSTGRESQL_OPENEDX_DB }} already exists"
+psql postgresql://{{ POSTGRESQL_ROOT_USER }}:{{ POSTGRESQL_ROOT_PASSWORD }}@{{ POSTGRESQL_HOST }}:{{ POSTGRESQL_PORT }} -c "CREATE USER {{ POSTGRESQL_OPENEDX_USER }} WITH PASSWORD '{{ POSTGRESQL_OPENEDX_PASSWORD }}';" 2>/dev/null || echo "User {{ POSTGRESQL_OPENEDX_USER }} already exists"
+psql postgresql://{{ POSTGRESQL_ROOT_USER }}:{{ POSTGRESQL_ROOT_PASSWORD }}@{{ POSTGRESQL_HOST }}:{{ POSTGRESQL_PORT }} -c "GRANT ALL PRIVILEGES ON DATABASE {{ POSTGRESQL_OPENEDX_DB }} TO {{ POSTGRESQL_OPENEDX_USER }};"
+psql postgresql://{{ POSTGRESQL_ROOT_USER }}:{{ POSTGRESQL_ROOT_PASSWORD }}@{{ POSTGRESQL_HOST }}:{{ POSTGRESQL_PORT }}/{{ POSTGRESQL_OPENEDX_DB }} -c "GRANT ALL ON SCHEMA public TO {{ POSTGRESQL_OPENEDX_USER }};"


### PR DESCRIPTION
This PR brings the following changes:

- Adds the init job to create DB users and Openedx DB
- Changes to the configuration settings:

1. POSTGRES_USER AND POSTGRES_PASSWORD changed to POSTGRES_ROOT_USER and POSTGRES_ROOT_PASSWORD
2. Added POSTGRES_OPENEDX_DB, POSTGRES_OPENEDX_USER, POSTGRES_OPENEDX_PASSWORD
3. Added POSTGRES_PORT for external postgres DB support

Finally, we should remove the mysql init job as well but that should be part of a separate PR in which we also set the RUN_MYSQL value to false and change the MYSQL_HOST and MYSQL_PORT to the postgresql ones as tutor needs them during the [lms](https://github.com/overhangio/tutor/blob/3f53104316761df4de4c526bfe72477e60050187/tutor/templates/jobs/init/lms.sh#L1) and [cms](https://github.com/overhangio/tutor/blob/3f53104316761df4de4c526bfe72477e60050187/tutor/templates/jobs/init/cms.sh#L1) jobs