### PR TITLE
chore: bump minimum tutor version to 19.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 
 ]
 dependencies = [
-    "tutor>=19.0.0,<20.0.0",
+    "tutor>=19.0.2,<20.0.0",
 ]
-optional-dependencies = { dev = ["tutor[dev]>=19.0.0,<20.0.0"] }
+optional-dependencies = { dev = ["tutor[dev]>=19.0.2,<20.0.0"] }
 
 # These fields will be set by hatch_build.py
 dynamic = ["version"]


### PR DESCRIPTION
The openedx-auth patch was moved to the bottom of the auth.yml file in tutor v19.0.2 in https://github.com/overhangio/tutor/pull/1191. 

This change is necessary to allow patching the database setting for setting postgresql as the main database through the openedx-auth used by openedx to connect to the database.